### PR TITLE
Add missing prettier rules dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.14.1",
     "eslint-config-airbnb": "17.1.0",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",


### PR DESCRIPTION
eslint-config-prettier is extended by this config, but it wasn't specified as a dependency.